### PR TITLE
feat(test-runner-v3): add task_id in test results

### DIFF
--- a/test/fixtures/reverse-string/.eslintignore
+++ b/test/fixtures/reverse-string/.eslintignore
@@ -1,0 +1,12 @@
+!.meta
+
+# Protected or generated
+.git
+.vscode
+
+# When using npm
+node_modules/*
+
+# Configuration files
+babel.config.js
+jest.config.js

--- a/test/fixtures/reverse-string/.eslintrc
+++ b/test/fixtures/reverse-string/.eslintrc
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "extends": "@exercism/eslint-config-typescript",
+  "env": {
+    "jest": true
+  },
+  "overrides": [
+    {
+      "files": [".meta/proof.ci.ts", ".meta/exemplar.ts", "*.test.ts"],
+      "excludedFiles": ["custom.test.ts"],
+      "extends": "@exercism/eslint-config-typescript/maintainers"
+    }
+  ]
+}

--- a/test/fixtures/reverse-string/.exercism/config.json
+++ b/test/fixtures/reverse-string/.exercism/config.json
@@ -1,0 +1,12 @@
+{
+  "blurb": "Reverse a string",
+  "authors": ["CRivasGomez"],
+  "contributors": ["masters3d", "SleeplessByte"],
+  "files": {
+    "solution": ["reverse-string.ts"],
+    "test": ["reverse-string.test.ts"],
+    "example": [".meta/proof.ci.ts"]
+  },
+  "source": "Introductory challenge to reverse an input string",
+  "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
+}

--- a/test/fixtures/reverse-string/.exercism/metadata.json
+++ b/test/fixtures/reverse-string/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"typescript","exercise":"reverse-string","id":"570c7eda0d6247fd943817fc29f9713a","url":"https://exercism.org/tracks/typescript/exercises/reverse-string","handle":"jelorivera08","is_requester":true,"auto_approve":false}

--- a/test/fixtures/reverse-string/.meta/config.json
+++ b/test/fixtures/reverse-string/.meta/config.json
@@ -1,0 +1,35 @@
+{
+    "blurb": "Reverse a string",
+    "authors": ["CRivasGomez"],
+    "contributors": ["masters3d", "SleeplessByte"],
+    "files": {
+      "solution": ["reverse-string.ts"],
+      "test": ["reverse-string.test.ts"],
+      "example": [".meta/proof.ci.ts"]
+    },
+    "source": "Introductory challenge to reverse an input string",
+    "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb",
+    "test_mapping" : [
+      {
+        "id": 1,
+        "name": "Reverse String > an empty string"
+      },
+      {
+        "id": 2,
+        "name": "Reverse String > a word"
+      },
+      {
+        "id": 3,
+        "name": "Reverse String > a capitalized word"
+      },
+      {
+        "id": 4,
+        "name": "Reverse String > a sentence with punctuation"
+      },
+      { 
+        "id": 5,
+        "name": "Reverse String > a palindrome"
+      }
+    ]
+  }
+  

--- a/test/fixtures/reverse-string/HELP.md
+++ b/test/fixtures/reverse-string/HELP.md
@@ -1,0 +1,44 @@
+# Help
+
+## Running the tests
+
+Execute the tests with:
+
+```bash
+$ yarn test
+```
+
+## Skipped tests
+
+In the test suites all tests but the first have been skipped.
+
+Once you get a test passing, you can enable the next one by changing `xit` to
+`it`.
+
+## Submitting your solution
+
+You can submit your solution using the `exercism submit reverse-string.ts` command.
+This command will upload your solution to the Exercism website and print the solution page's URL.
+
+It's possible to submit an incomplete solution which allows you to:
+
+- See how others have completed the exercise
+- Request help from a mentor
+
+## Need to get help?
+
+If you'd like help solving the exercise, check the following pages:
+
+- The [TypeScript track's documentation](https://exercism.org/docs/tracks/typescript)
+- [Exercism's support channel on gitter](https://gitter.im/exercism/support)
+- The [Frequently Asked Questions](https://exercism.org/docs/using/faqs)
+
+Should those resources not suffice, you could submit your (incomplete) solution to request mentoring.
+
+To get help if you're having trouble, you can use one of the following resources:
+
+- [TypeScript QuickStart](https://www.typescriptlang.org/docs/tutorial.html)
+- [ECMAScript 2015 Language Specification](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf) (pdf)
+- [Mozilla JavaScript Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
+- [/r/typescript](https://www.reddit.com/r/typescript) is the TypeScript subreddit.
+- [StackOverflow](http://stackoverflow.com/questions/tagged/typescript) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.

--- a/test/fixtures/reverse-string/README.md
+++ b/test/fixtures/reverse-string/README.md
@@ -1,0 +1,27 @@
+# Reverse String
+
+Welcome to Reverse String on Exercism's TypeScript Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Reverse a string
+
+For example:
+input: "cool"
+output: "looc"
+
+## Source
+
+### Created by
+
+- @CRivasGomez
+
+### Contributed to by
+
+- @masters3d
+- @SleeplessByte
+
+### Based on
+
+Introductory challenge to reverse an input string - https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb

--- a/test/fixtures/reverse-string/babel.config.js
+++ b/test/fixtures/reverse-string/babel.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+        useBuiltIns: 'entry',
+        corejs: '3.17',
+      },
+    ],
+    '@babel/preset-typescript',
+  ],
+  plugins: [
+    '@babel/proposal-class-properties',
+    '@babel/proposal-object-rest-spread',
+    '@babel/plugin-syntax-bigint',
+  ],
+}

--- a/test/fixtures/reverse-string/jest.config.js
+++ b/test/fixtures/reverse-string/jest.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  verbose: true,
+  projects: ['<rootDir>'],
+  testMatch: [
+    '**/__tests__/**/*.[jt]s?(x)',
+    '**/test/**/*.[jt]s?(x)',
+    '**/?(*.)+(spec|test).[jt]s?(x)',
+  ],
+  testPathIgnorePatterns: [
+    '/(?:production_)?node_modules/',
+    '.d.ts$',
+    '<rootDir>/test/fixtures',
+    '<rootDir>/test/helpers',
+    '__mocks__',
+  ],
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
+}

--- a/test/fixtures/reverse-string/package.json
+++ b/test/fixtures/reverse-string/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@exercism/typescript-reverse-string",
+  "version": "1.0.0",
+  "description": "Exercism exercises in Typescript.",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/typescript"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.15.5",
+    "@babel/plugin-proposal-class-properties": "^7.14.5",
+    "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
+    "@babel/plugin-syntax-bigint": "^7.8.3",
+    "@babel/preset-env": "^7.15.4",
+    "@babel/preset-typescript": "^7.15.0",
+    "@types/jest": "^26.0.24",
+    "@types/node": "^14.17.14",
+    "@exercism/eslint-config-typescript": "^0.3.0",
+    "babel-jest": "^26.6.3",
+    "core-js": "^3.17.2",
+    "eslint": "^7.32.0",
+    "eslint-plugin-import": "^2.24.2",
+    "jest": "^26.6.3",
+    "typescript": "^4.4.2"
+  },
+  "scripts": {
+    "test": "yarn lint:types && jest --no-cache",
+    "lint": "yarn lint:types && yarn lint:ci",
+    "lint:types": "yarn tsc --noEmit -p .",
+    "lint:ci": "eslint . --ext .tsx,.ts"
+  }
+}

--- a/test/fixtures/reverse-string/reverse-string.test.ts
+++ b/test/fixtures/reverse-string/reverse-string.test.ts
@@ -1,0 +1,29 @@
+import { reverse } from './reverse-string'
+
+describe('Reverse String', () => {
+  // @jelo jelo 123
+  it('an empty string', () => {
+    const expected = ''
+    expect(reverse('')).toEqual(expected)
+  })
+
+  it('a word', () => {
+    const expected = 'tobor'
+    expect(reverse('robot')).toEqual(expected)
+  })
+
+  it('a capitalized word', () => {
+    const expected = 'nemaR'
+    expect(reverse('Ramen')).toEqual(expected)
+  })
+
+  it('a sentence with punctuation', () => {
+    const expected = `!yrgnuh m'I`
+    expect(reverse(`I'm hungry!`)).toEqual(expected)
+  })
+
+  it('a palindrome', () => {
+    const expected = 'racecar'
+    expect(reverse('racecar')).toEqual(expected)
+  })
+})

--- a/test/fixtures/reverse-string/reverse-string.test.tstmp
+++ b/test/fixtures/reverse-string/reverse-string.test.tstmp
@@ -1,0 +1,28 @@
+import { reverse } from './reverse-string'
+
+describe('Reverse String', () => {
+  it('an empty string', () => {
+    const expected = ''
+    expect(reverse('')).toEqual(expected)
+  })
+
+  it('a word', () => {
+    const expected = 'tobor'
+    expect(reverse('robot')).toEqual(expected)
+  })
+
+  it('a capitalized word', () => {
+    const expected = 'nemaR'
+    expect(reverse('Ramen')).toEqual(expected)
+  })
+
+  it('a sentence with punctuation', () => {
+    const expected = `!yrgnuh m'I`
+    expect(reverse(`I'm hungry!`)).toEqual(expected)
+  })
+
+  it('a palindrome', () => {
+    const expected = 'racecar'
+    expect(reverse('racecar')).toEqual(expected)
+  })
+})

--- a/test/fixtures/reverse-string/reverse-string.ts
+++ b/test/fixtures/reverse-string/reverse-string.ts
@@ -1,0 +1,3 @@
+export function reverse(str: string): string {
+ return str.split('').reverse().join('');
+}

--- a/test/fixtures/reverse-string/tsconfig.json
+++ b/test/fixtures/reverse-string/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "display": "Configuration for Node LTS",
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "target": "es2020",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // Because we'll be using babel
+    // Ensure that Babel can safely transpile files in the TypeScript project
+    "isolatedModules": true
+  },
+  "include": ["*", ".meta/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Issue: https://github.com/exercism/typescript-test-runner/issues/16

This PR uses the `./meta/config.json` to map out the task id and names. and returns a task_id in the results object when everything checks out. 

Changes: 
- Fetch the metadata JSON every time a test starts and assign it to the metadata variable of output.
- in the `testInnerFinished` function, check if a taskId is available for a certain test and have it returned in the results object.

Up for discussion:
- Naming conventions for the key used in the config metadata `test_mapping`.
- Should we fetch the metadata every test or in the initialization of the Output Class?
- More performant way of fetching metadata JSON file.