### PR TITLE
Make prettier ignore CODE_OF_CONDUCT.md file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 /tmp
 /dist
 /node_modules
+/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Ignore this automatically synced file to prevent the file from having to be formatted each time an org-wide-files run is done.