### PR TITLE
Drop chmod commands that break Docker image build and are no longer needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,6 @@ RUN set -ex; \
 # https://github.com/nodejs/corepack/pull/446#issue-2218976611
 RUN corepack install
 RUN corepack yarn --version
-# https://github.com/nodejs/corepack/issues/414#issuecomment-2096218732
-# https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/folderUtils.ts#L26-L31
-RUN chmod 444 /idk/corepack/lastKnownGood.json
-RUN chmod 555 /idk/corepack
 
 # Build the test runner
 RUN set -ex; \


### PR DESCRIPTION
This should fix the CI failures in the other open PRs.